### PR TITLE
fix for directory not found bug

### DIFF
--- a/crossflow/tasks.py
+++ b/crossflow/tasks.py
@@ -239,6 +239,7 @@ class FunctionTask(object):
             Whatever the function returns, with output files converted
                 to FileHandle objects
         """
+        od = os.getcwd()
         td = tempfile.mkdtemp()
         os.chdir(td)
         indict = {}
@@ -284,7 +285,7 @@ class FunctionTask(object):
             else:
                 outputs.append(v)
             shutil.rmtree(td, ignore_errors=True)
-
+        os.chdir(od)
         if len(outputs) == 1:
             outputs = outputs[0]
         else:


### PR DESCRIPTION
This commit should resolve a bug when using FunctionTask methods that the directory is removed but then not changed back into, so any further operations (even os.getcwd()) will cause an exception to be thrown that the directory does not exist.

I'm not sure however I have got the level of indentation correct or not for all cases!

closes #3 