### PR TITLE
Re-add macos tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        #os: [macos-15, ubuntu-24.04, windows-2025]
-        os: [ubuntu-24.04, windows-2025]
+        os: [macos-15, ubuntu-24.04, windows-2025]
         python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
Once the upstream issue with coveralls has been fixed by the action maintainers then merge this

closes #7